### PR TITLE
Upgrades dependencies and adds support for newly added jansi methods

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -6,9 +6,9 @@
             :comment "MIT License"
             :year 2021
             :key "mit"}
-  :dependencies [[org.clojure/clojure "1.10.3" :scope "provided"]
-                 [org.fusesource.jansi/jansi "2.4.0"]]
-  :profiles {:doc {:plugins [[codox "0.10.3"]]
+  :dependencies [[org.clojure/clojure "1.11.1" :scope "provided"]
+                 [org.fusesource.jansi/jansi "2.4.1"]]
+  :profiles {:doc {:plugins [[codox "0.10.8"]]
                    :codox {:exclude [jansi-clj.auto]
                            :src-dir-uri "https://github.com/xsc/jansi-clj/blob/master/"
                            :src-linenum-anchor-prefix "L"}}}

--- a/src/jansi_clj/core.clj
+++ b/src/jansi_clj/core.clj
@@ -229,14 +229,34 @@
   (.cursorRight x))
 
 (def-screen-fns save-cursor
-  "Save cursor position. Note: doesn't work on most terminals."
+  "Save cursor position. Note: this issues both DEC and SCO escape sequences, for maximum compatibility across terminal emulators."
   []
   (.saveCursorPosition))
 
 (def-screen-fns restore-cursor
-  "Restore cursor position. Note: doesn't work on most terminals."
+  "Restore cursor position. Note: this issues both DEC and SCO escape sequences, for maximum compatibility across terminal emulators."
   []
   (.restorCursorPosition))
+
+(def-screen-fns save-cursor-dec
+  "Save cursor position. Note: DEC escape sequence only."
+  []
+  (.saveCursorPositionDEC))
+
+(def-screen-fns restore-cursor-dec
+  "Restore cursor position. Note: DEC escape sequence only."
+  []
+  (.restorCursorPositionDEC))
+
+(def-screen-fns save-cursor-sco
+  "Save cursor position. Note: SCO escape sequence only."
+  []
+  (.saveCursorPositionSCO))
+
+(def-screen-fns restore-cursor-sco
+  "Restore cursor position. Note: SCO escape sequence only."
+  []
+  (.restorCursorPositionSCO))
 
 ;; ## Enable/Disable/Install/Uninstall
 


### PR DESCRIPTION
This PR upgrades all outdated dependencies (Clojure, jansi, and codox), and adds direct support for the DEC/SCO variants of save and restore cursor position (added in [jansi v2.4.1](https://github.com/fusesource/jansi/releases/tag/jansi-2.4.1)).