### PR TITLE
Fix typos in Java method names

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,12 @@ jobs:
           check-name: clj-kondo
           github_token: ${{ secrets.GITHUB_TOKEN }}
 
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - run: lein check
+
   test:
     runs-on: ubuntu-latest
     steps:

--- a/src/jansi_clj/core.clj
+++ b/src/jansi_clj/core.clj
@@ -238,7 +238,7 @@
 (def-screen-fns restore-cursor
   "Restore cursor position. Note: this issues both DEC and SCO escape sequences, for maximum compatibility across terminal emulators."
   []
-  (.restorCursorPosition))
+  (.restoreCursorPosition))
 
 (def-screen-fns save-cursor-dec
   "Save cursor position. Note: DEC escape sequence only."
@@ -248,7 +248,7 @@
 (def-screen-fns restore-cursor-dec
   "Restore cursor position. Note: DEC escape sequence only."
   []
-  (.restorCursorPositionDEC))
+  (.restoreCursorPositionDEC))
 
 (def-screen-fns save-cursor-sco
   "Save cursor position. Note: SCO escape sequence only."
@@ -258,7 +258,7 @@
 (def-screen-fns restore-cursor-sco
   "Restore cursor position. Note: SCO escape sequence only."
   []
-  (.restorCursorPositionSCO))
+  (.restoreCursorPositionSCO))
 
 ;; ## Enable/Disable/Install/Uninstall
 


### PR DESCRIPTION
This PR fixes typos in Java method names that were accidentally introduced in PR #6.  It also adds `lein check` to the CI script, in an attempt to have a better idea when this kind of thing happens (though in my testing a failed `lein check` still returns a zero exit code, so GitHub won't fail the job even when a `lein check` fails... 🤦‍♂️).

Sorry again for the hassle @xsc.